### PR TITLE
Fix two consensus vulnerabilities related to founders payment and skipped payee validation

### DIFF
--- a/src/founder_payment.cpp
+++ b/src/founder_payment.cpp
@@ -58,7 +58,7 @@ bool FounderPayment::IsBlockPayeeValid(const CTransaction& txNew, const int heig
 	const CAmount founderReward = getFounderPaymentAmount(height, blockReward);
 	//std::cout << "founderReward = " << founderReward << endl;
 	BOOST_FOREACH(const CTxOut& out, txNew.vout) {
-		if(out.scriptPubKey == payee && out.nValue >= founderReward) {
+		if(out.scriptPubKey == payee && out.nValue == founderReward) {
 			return true;
 		}
 	}

--- a/src/smartnode/smartnode-payments.cpp
+++ b/src/smartnode/smartnode-payments.cpp
@@ -162,12 +162,6 @@ bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockRewar
 
 bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward, CAmount specialTxFees)
 {
-    if(fLiteMode) {
-        //there is no budget data to use to check anything, let's just accept the longest chain
-        LogPrint(BCLog::MNPAYMENTS, "%s -- WARNING: Not enough data, skipping block payee checks\n", __func__);
-        return true;
-    }
-
     // we are still using budgets, but we have no data about them anymore,
     // we can only check smartnode payments
 


### PR DESCRIPTION
1. Founder Payment Overpayment: Changed >= to == in FounderPayment::IsBlockPayeeValid to enforce exact founder reward amount, preventing over-allocation to founder address.

2. Lite Mode Payee Bypass: Removed fLiteMode early return in IsBlockPayeeValid that skipped all payee validation (smartnode, founder, superblock payments).